### PR TITLE
Fix Object.keys called on non-object error.

### DIFF
--- a/src/common/gwt.coffee
+++ b/src/common/gwt.coffee
@@ -36,7 +36,7 @@ withContext = (object, keyword, fn) ->
   fn.apply keyword.get(object)
 
 proxyOnSelf = (container, object) ->
-  keys = Object.keys(object)
+  keys = Object.keys(object or {})
 
   keys.forEach (key) ->
     Object.defineProperty container, key,


### PR DESCRIPTION
Sometimes gwt.results objects can be purposefully undefined (when used as an optional argument for example). Without this change it will cause `Object.keys called on non-object` to be thrown.
